### PR TITLE
Parse unknown metadata and write metadata

### DIFF
--- a/src/mp4box/data.rs
+++ b/src/mp4box/data.rs
@@ -13,6 +13,39 @@ pub struct DataBox {
     pub data_type: DataType,
 }
 
+impl DataBox {
+    pub fn get_type(&self) -> BoxType {
+        BoxType::DataBox
+    }
+
+    pub fn get_size(&self) -> u64 {
+        let mut size = HEADER_SIZE;
+        size += 4; // data_type
+        size += 4; // reserved
+        size += self.data.len() as u64;
+        size
+    }
+}
+
+impl Mp4Box for DataBox {
+    fn box_type(&self) -> BoxType {
+        self.get_type()
+    }
+
+    fn box_size(&self) -> u64 {
+        self.get_size()
+    }
+
+    fn to_json(&self) -> Result<String> {
+        Ok(serde_json::to_string(&self).unwrap())
+    }
+
+    fn summary(&self) -> Result<String> {
+        let s = format!("type={:?} len={}", self.data_type, self.data.len());
+        Ok(s)
+    }
+}
+
 impl<R: Read + Seek> ReadBox<&mut R> for DataBox {
     fn read_box(reader: &mut R, size: u64) -> Result<Self> {
         let start = box_start(reader)?;
@@ -26,5 +59,60 @@ impl<R: Read + Seek> ReadBox<&mut R> for DataBox {
         reader.read_exact(&mut data)?;
 
         Ok(DataBox { data, data_type })
+    }
+}
+
+impl<W: Write> WriteBox<&mut W> for DataBox {
+    fn write_box(&self, writer: &mut W) -> Result<u64> {
+        let size = self.box_size();
+        BoxHeader::new(self.box_type(), size).write(writer)?;
+
+        writer.write_u32::<BigEndian>(self.data_type.clone() as u32)?;
+        writer.write_u32::<BigEndian>(0)?; // reserved = 0
+        writer.write_all(&self.data)?;
+
+        Ok(size)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mp4box::BoxHeader;
+    use std::io::Cursor;
+
+    #[test]
+    fn test_data() {
+        let src_box = DataBox {
+            data_type: DataType::Text,
+            data: b"test_data".to_vec(),
+        };
+        let mut buf = Vec::new();
+        src_box.write_box(&mut buf).unwrap();
+        assert_eq!(buf.len(), src_box.box_size() as usize);
+
+        let mut reader = Cursor::new(&buf);
+        let header = BoxHeader::read(&mut reader).unwrap();
+        assert_eq!(header.name, BoxType::DataBox);
+        assert_eq!(src_box.box_size(), header.size);
+
+        let dst_box = DataBox::read_box(&mut reader, header.size).unwrap();
+        assert_eq!(src_box, dst_box);
+    }
+
+    #[test]
+    fn test_data_empty() {
+        let src_box = DataBox::default();
+        let mut buf = Vec::new();
+        src_box.write_box(&mut buf).unwrap();
+        assert_eq!(buf.len(), src_box.box_size() as usize);
+
+        let mut reader = Cursor::new(&buf);
+        let header = BoxHeader::read(&mut reader).unwrap();
+        assert_eq!(header.name, BoxType::DataBox);
+        assert_eq!(src_box.box_size(), header.size);
+
+        let dst_box = DataBox::read_box(&mut reader, header.size).unwrap();
+        assert_eq!(src_box, dst_box);
     }
 }

--- a/src/mp4box/ilst.rs
+++ b/src/mp4box/ilst.rs
@@ -13,6 +13,39 @@ pub struct IlstBox {
     pub items: HashMap<MetadataKey, IlstItemBox>,
 }
 
+impl IlstBox {
+    pub fn get_type(&self) -> BoxType {
+        BoxType::IlstBox
+    }
+
+    pub fn get_size(&self) -> u64 {
+        let mut size = HEADER_SIZE;
+        for item in self.items.values() {
+            size += item.get_size();
+        }
+        size
+    }
+}
+
+impl Mp4Box for IlstBox {
+    fn box_type(&self) -> BoxType {
+        self.get_type()
+    }
+
+    fn box_size(&self) -> u64 {
+        self.get_size()
+    }
+
+    fn to_json(&self) -> Result<String> {
+        Ok(serde_json::to_string(&self).unwrap())
+    }
+
+    fn summary(&self) -> Result<String> {
+        let s = format!("item_count={}", self.items.len());
+        Ok(s)
+    }
+}
+
 impl<R: Read + Seek> ReadBox<&mut R> for IlstBox {
     fn read_box(reader: &mut R, size: u64) -> Result<Self> {
         let start = box_start(reader)?;
@@ -54,9 +87,34 @@ impl<R: Read + Seek> ReadBox<&mut R> for IlstBox {
     }
 }
 
+impl<W: Write> WriteBox<&mut W> for IlstBox {
+    fn write_box(&self, writer: &mut W) -> Result<u64> {
+        let size = self.box_size();
+        BoxHeader::new(self.box_type(), size).write(writer)?;
+
+        for (key, value) in &self.items {
+            let name = match key {
+                MetadataKey::Title => BoxType::NameBox,
+                MetadataKey::Year => BoxType::DayBox,
+                MetadataKey::Poster => BoxType::CovrBox,
+                MetadataKey::Summary => BoxType::DescBox,
+            };
+            BoxHeader::new(name, value.get_size()).write(writer)?;
+            value.data.write_box(writer)?;
+        }
+        Ok(size)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
 pub struct IlstItemBox {
     pub data: DataBox,
+}
+
+impl IlstItemBox {
+    fn get_size(&self) -> u64 {
+        HEADER_SIZE + self.data.box_size()
+    }
 }
 
 impl<R: Read + Seek> ReadBox<&mut R> for IlstItemBox {
@@ -128,5 +186,58 @@ fn item_to_u32(item: &IlstItemBox) -> Option<u32> {
         DataType::Binary if item.data.data.len() == 4 => Some(BigEndian::read_u32(&item.data.data)),
         DataType::Text => String::from_utf8_lossy(&item.data.data).parse::<u32>().ok(),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mp4box::BoxHeader;
+    use std::io::Cursor;
+
+    #[test]
+    fn test_ilst() {
+        let src_year = IlstItemBox {
+            data: DataBox {
+                data_type: DataType::Text,
+                data: b"test_year".to_vec(),
+            },
+        };
+        let src_box = IlstBox {
+            items: [
+                (MetadataKey::Title, IlstItemBox::default()),
+                (MetadataKey::Year, src_year),
+                (MetadataKey::Poster, IlstItemBox::default()),
+                (MetadataKey::Summary, IlstItemBox::default()),
+            ]
+            .into(),
+        };
+        let mut buf = Vec::new();
+        src_box.write_box(&mut buf).unwrap();
+        assert_eq!(buf.len(), src_box.box_size() as usize);
+
+        let mut reader = Cursor::new(&buf);
+        let header = BoxHeader::read(&mut reader).unwrap();
+        assert_eq!(header.name, BoxType::IlstBox);
+        assert_eq!(src_box.box_size(), header.size);
+
+        let dst_box = IlstBox::read_box(&mut reader, header.size).unwrap();
+        assert_eq!(src_box, dst_box);
+    }
+
+    #[test]
+    fn test_ilst_empty() {
+        let src_box = IlstBox::default();
+        let mut buf = Vec::new();
+        src_box.write_box(&mut buf).unwrap();
+        assert_eq!(buf.len(), src_box.box_size() as usize);
+
+        let mut reader = Cursor::new(&buf);
+        let header = BoxHeader::read(&mut reader).unwrap();
+        assert_eq!(header.name, BoxType::IlstBox);
+        assert_eq!(src_box.box_size(), header.size);
+
+        let dst_box = IlstBox::read_box(&mut reader, header.size).unwrap();
+        assert_eq!(src_box, dst_box);
     }
 }

--- a/src/mp4box/meta.rs
+++ b/src/mp4box/meta.rs
@@ -2,13 +2,38 @@ use std::io::{Read, Seek};
 
 use serde::Serialize;
 
+use crate::mp4box::hdlr::HdlrBox;
 use crate::mp4box::ilst::IlstBox;
 use crate::mp4box::*;
 
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
-pub struct MetaBox {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub ilst: Option<IlstBox>,
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "hdlr")]
+#[serde(rename_all = "lowercase")]
+pub enum MetaBox {
+    Mdir {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        ilst: Option<IlstBox>,
+    },
+
+    #[serde(skip)]
+    Unknown {
+        #[serde(skip)]
+        hdlr: HdlrBox,
+
+        #[serde(skip)]
+        data: Vec<u8>,
+    },
+}
+
+const MDIR: FourCC = FourCC { value: *b"mdir" };
+
+impl Default for MetaBox {
+    fn default() -> Self {
+        Self::Unknown {
+            hdlr: Default::default(),
+            data: Default::default(),
+        }
+    }
 }
 
 impl<R: Read + Seek> ReadBox<&mut R> for MetaBox {
@@ -20,30 +45,110 @@ impl<R: Read + Seek> ReadBox<&mut R> for MetaBox {
             return Err(Error::UnsupportedBoxVersion(BoxType::UdtaBox, version));
         }
 
+        let hdlr_header = BoxHeader::read(reader)?;
+        if hdlr_header.name != BoxType::HdlrBox {
+            return Err(Error::BoxNotFound(BoxType::HdlrBox));
+        }
+        let hdlr = HdlrBox::read_box(reader, hdlr_header.size)?;
+
         let mut ilst = None;
 
         let mut current = reader.seek(SeekFrom::Current(0))?;
         let end = start + size;
-        while current < end {
-            // Get box header.
-            let header = BoxHeader::read(reader)?;
-            let BoxHeader { name, size: s } = header;
 
-            match name {
-                BoxType::IlstBox => {
-                    ilst = Some(IlstBox::read_box(reader, s)?);
+        match hdlr.handler_type {
+            MDIR => {
+                while current < end {
+                    // Get box header.
+                    let header = BoxHeader::read(reader)?;
+                    let BoxHeader { name, size: s } = header;
+
+                    match name {
+                        BoxType::IlstBox => {
+                            ilst = Some(IlstBox::read_box(reader, s)?);
+                        }
+                        _ => {
+                            // XXX warn!()
+                            skip_box(reader, s)?;
+                        }
+                    }
+
+                    current = reader.seek(SeekFrom::Current(0))?;
                 }
-                _ => {
-                    // XXX warn!()
-                    skip_box(reader, s)?;
-                }
+
+                Ok(MetaBox::Mdir { ilst })
             }
+            _ => {
+                let mut data = vec![0u8; (end - current) as usize];
+                reader.read_exact(&mut data)?;
 
-            current = reader.seek(SeekFrom::Current(0))?;
+                Ok(MetaBox::Unknown { hdlr, data })
+            }
         }
+    }
+}
 
-        skip_bytes_to(reader, start + size)?;
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mp4box::BoxHeader;
+    use std::io::Cursor;
 
-        Ok(MetaBox { ilst })
+    #[test]
+    fn test_meta_mdir() {
+        let src_hdlr = HdlrBox {
+            handler_type: MDIR,
+            ..Default::default()
+        };
+        let src_header = BoxHeader::new(
+            BoxType::MetaBox,
+            HEADER_SIZE + HEADER_EXT_SIZE + src_hdlr.box_size(),
+        );
+
+        let mut buf = Vec::new();
+        src_header.write(&mut buf).unwrap();
+        write_box_header_ext(&mut buf, 0, 0).unwrap();
+        src_hdlr.write_box(&mut buf).unwrap();
+        assert_eq!(buf.len(), src_header.size as usize);
+
+        let mut reader = Cursor::new(&buf);
+        let header = BoxHeader::read(&mut reader).unwrap();
+        assert_eq!(header.name, src_header.name);
+        assert_eq!(header.size, src_header.size);
+
+        let dst_box = MetaBox::read_box(&mut reader, header.size).unwrap();
+        assert!(matches!(dst_box, MetaBox::Mdir { ilst: None }));
+    }
+
+    #[test]
+    fn test_meta_unknown() {
+        let src_hdlr = HdlrBox {
+            handler_type: FourCC::from(*b"test"),
+            ..Default::default()
+        };
+        let src_data = b"123";
+        let src_header = BoxHeader::new(
+            BoxType::MetaBox,
+            HEADER_SIZE + HEADER_EXT_SIZE + src_hdlr.box_size() + src_data.len() as u64,
+        );
+
+        let mut buf = Vec::new();
+        src_header.write(&mut buf).unwrap();
+        write_box_header_ext(&mut buf, 0, 0).unwrap();
+        src_hdlr.write_box(&mut buf).unwrap();
+
+        buf.extend(src_data);
+
+        assert_eq!(buf.len(), src_header.size as usize);
+
+        let mut reader = Cursor::new(&buf);
+        let header = BoxHeader::read(&mut reader).unwrap();
+        assert_eq!(header.name, src_header.name);
+        assert_eq!(header.size, src_header.size);
+
+        let dst_box = MetaBox::read_box(&mut reader, header.size).unwrap();
+        assert!(
+            matches!(dst_box, MetaBox::Unknown { hdlr, data } if data == src_data && hdlr == src_hdlr)
+        );
     }
 }

--- a/src/mp4box/meta.rs
+++ b/src/mp4box/meta.rs
@@ -62,7 +62,7 @@ impl Mp4Box for MetaBox {
 
     fn summary(&self) -> Result<String> {
         let s = match self {
-            Self::Mdir { .. } => format!("hdlr=ilst"),
+            Self::Mdir { .. } => "hdlr=ilst".to_string(),
             Self::Unknown { hdlr, data } => {
                 format!("hdlr={} data_len={}", hdlr.handler_type, data.len())
             }

--- a/src/mp4box/moov.rs
+++ b/src/mp4box/moov.rs
@@ -32,6 +32,12 @@ impl MoovBox {
         for trak in self.traks.iter() {
             size += trak.box_size();
         }
+        if let Some(meta) = &self.meta {
+            size += meta.box_size();
+        }
+        if let Some(udta) = &self.udta {
+            size += udta.box_size();
+        }
         size
     }
 }
@@ -123,6 +129,59 @@ impl<W: Write> WriteBox<&mut W> for MoovBox {
         for trak in self.traks.iter() {
             trak.write_box(writer)?;
         }
+        if let Some(meta) = &self.meta {
+            meta.write_box(writer)?;
+        }
+        if let Some(udta) = &self.udta {
+            udta.write_box(writer)?;
+        }
         Ok(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mp4box::BoxHeader;
+    use std::io::Cursor;
+
+    #[test]
+    fn test_moov() {
+        let src_box = MoovBox {
+            mvhd: MvhdBox::default(),
+            mvex: None, // XXX mvex is not written currently
+            traks: vec![],
+            meta: Some(MetaBox::default()),
+            udta: Some(UdtaBox::default()),
+        };
+
+        let mut buf = Vec::new();
+        src_box.write_box(&mut buf).unwrap();
+        assert_eq!(buf.len(), src_box.box_size() as usize);
+
+        let mut reader = Cursor::new(&buf);
+        let header = BoxHeader::read(&mut reader).unwrap();
+        assert_eq!(header.name, BoxType::MoovBox);
+        assert_eq!(header.size, src_box.box_size());
+
+        let dst_box = MoovBox::read_box(&mut reader, header.size).unwrap();
+        assert_eq!(dst_box, src_box);
+    }
+
+    #[test]
+    fn test_moov_empty() {
+        let src_box = MoovBox::default();
+
+        let mut buf = Vec::new();
+        src_box.write_box(&mut buf).unwrap();
+        assert_eq!(buf.len(), src_box.box_size() as usize);
+
+        let mut reader = Cursor::new(&buf);
+        let header = BoxHeader::read(&mut reader).unwrap();
+        assert_eq!(header.name, BoxType::MoovBox);
+        assert_eq!(header.size, src_box.box_size());
+
+        let dst_box = MoovBox::read_box(&mut reader, header.size).unwrap();
+        assert_eq!(dst_box, src_box);
     }
 }

--- a/src/mp4box/trak.rs
+++ b/src/mp4box/trak.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
 use std::io::{Read, Seek, SeekFrom, Write};
 
+use crate::meta::MetaBox;
 use crate::mp4box::*;
 use crate::mp4box::{edts::EdtsBox, mdia::MdiaBox, tkhd::TkhdBox};
 
@@ -10,6 +11,9 @@ pub struct TrakBox {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub edts: Option<EdtsBox>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub meta: Option<MetaBox>,
 
     pub mdia: MdiaBox,
 }
@@ -55,6 +59,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for TrakBox {
 
         let mut tkhd = None;
         let mut edts = None;
+        let mut meta = None;
         let mut mdia = None;
 
         let mut current = reader.seek(SeekFrom::Current(0))?;
@@ -70,6 +75,9 @@ impl<R: Read + Seek> ReadBox<&mut R> for TrakBox {
                 }
                 BoxType::EdtsBox => {
                     edts = Some(EdtsBox::read_box(reader, s)?);
+                }
+                BoxType::MetaBox => {
+                    meta = Some(MetaBox::read_box(reader, s)?);
                 }
                 BoxType::MdiaBox => {
                     mdia = Some(MdiaBox::read_box(reader, s)?);
@@ -95,6 +103,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for TrakBox {
         Ok(TrakBox {
             tkhd: tkhd.unwrap(),
             edts,
+            meta,
             mdia: mdia.unwrap(),
         })
     }

--- a/src/mp4box/udta.rs
+++ b/src/mp4box/udta.rs
@@ -11,6 +11,38 @@ pub struct UdtaBox {
     pub meta: Option<MetaBox>,
 }
 
+impl UdtaBox {
+    pub fn get_type(&self) -> BoxType {
+        BoxType::UdtaBox
+    }
+
+    pub fn get_size(&self) -> u64 {
+        let mut size = HEADER_SIZE;
+        if let Some(meta) = &self.meta {
+            size += meta.box_size();
+        }
+        size
+    }
+}
+
+impl Mp4Box for UdtaBox {
+    fn box_type(&self) -> BoxType {
+        self.get_type()
+    }
+
+    fn box_size(&self) -> u64 {
+        self.get_size()
+    }
+
+    fn to_json(&self) -> Result<String> {
+        Ok(serde_json::to_string(&self).unwrap())
+    }
+
+    fn summary(&self) -> Result<String> {
+        Ok(String::new())
+    }
+}
+
 impl<R: Read + Seek> ReadBox<&mut R> for UdtaBox {
     fn read_box(reader: &mut R, size: u64) -> Result<Self> {
         let start = box_start(reader)?;
@@ -40,5 +72,60 @@ impl<R: Read + Seek> ReadBox<&mut R> for UdtaBox {
         skip_bytes_to(reader, start + size)?;
 
         Ok(UdtaBox { meta })
+    }
+}
+
+impl<W: Write> WriteBox<&mut W> for UdtaBox {
+    fn write_box(&self, writer: &mut W) -> Result<u64> {
+        let size = self.box_size();
+        BoxHeader::new(self.box_type(), size).write(writer)?;
+
+        if let Some(meta) = &self.meta {
+            meta.write_box(writer)?;
+        }
+        Ok(size)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mp4box::BoxHeader;
+    use std::io::Cursor;
+
+    #[test]
+    fn test_udta_empty() {
+        let src_box = UdtaBox { meta: None };
+
+        let mut buf = Vec::new();
+        src_box.write_box(&mut buf).unwrap();
+        assert_eq!(buf.len(), src_box.box_size() as usize);
+
+        let mut reader = Cursor::new(&buf);
+        let header = BoxHeader::read(&mut reader).unwrap();
+        assert_eq!(header.name, BoxType::UdtaBox);
+        assert_eq!(header.size, src_box.box_size());
+
+        let dst_box = UdtaBox::read_box(&mut reader, header.size).unwrap();
+        assert_eq!(dst_box, src_box);
+    }
+
+    #[test]
+    fn test_udta() {
+        let src_box = UdtaBox {
+            meta: Some(MetaBox::default()),
+        };
+
+        let mut buf = Vec::new();
+        src_box.write_box(&mut buf).unwrap();
+        assert_eq!(buf.len(), src_box.box_size() as usize);
+
+        let mut reader = Cursor::new(&buf);
+        let header = BoxHeader::read(&mut reader).unwrap();
+        assert_eq!(header.name, BoxType::UdtaBox);
+        assert_eq!(header.size, src_box.box_size());
+
+        let dst_box = UdtaBox::read_box(&mut reader, header.size).unwrap();
+        assert_eq!(dst_box, src_box);
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::io::{Read, Seek, SeekFrom};
 use std::time::Duration;
 
+use crate::meta::MetaBox;
 use crate::*;
 
 #[derive(Debug)]
@@ -170,9 +171,11 @@ impl<R: Read + Seek> Mp4Reader<R> {
 
 impl<R> Mp4Reader<R> {
     pub fn metadata(&self) -> impl Metadata<'_> {
-        self.moov
-            .udta
-            .as_ref()
-            .and_then(|udta| udta.meta.as_ref().and_then(|meta| meta.ilst.as_ref()))
+        self.moov.udta.as_ref().and_then(|udta| {
+            udta.meta.as_ref().and_then(|meta| match meta {
+                MetaBox::Mdir { ilst } => ilst.as_ref(),
+                _ => None,
+            })
+        })
     }
 }


### PR DESCRIPTION
This is a duplicate of https://github.com/alfg/mp4-rust/pull/91 for internal review.

The meta box is very open-ended, leaving itself open to extension by future specs. This PR:

1) parses the Hdlrbox as required by the spec for the meta box
2) only parses iTunes metadata when the handler type is mdir (as seen in `big_buck_bunny_metadata.m4v)
3) makes MetaBox into an enum, to allow for other handlers in the future (like requested in https://github.com/alfg/mp4-rust/issues/66)
4) allows parsing MetaBox in more positions as per the spec
5) writes metadata out if present